### PR TITLE
Replace URI with urllib.parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ To use the `il2_rest` package, you can add the interlockledger_rest folder to yo
     * packaging (19.2)
     * pyOpenSSL (19.1.0)
     * requests (2.22.0)
-    * uri (2.0.1)
     * pyilint (0.2.0)
     * pyiltags (0.0.1)
 * InterlockLedger :

--- a/il2_rest/client.py
+++ b/il2_rest/client.py
@@ -63,7 +63,13 @@ from .util import build_query
 from .util import PKCS12Certificate
 
 
+class UrlJoinException:
+    ...
+
+
 def urljoin(base, path):
+    if urllib.parse.urlsplit(path).netloc != '':
+        raise UrlJoinException()
     return urllib.parse.urljoin(base, urllib.parse.urlparse(path).path)
 
 

--- a/il2_rest/client.py
+++ b/il2_rest/client.py
@@ -29,7 +29,7 @@
 import os
 import contextlib
 import tempfile
-import uri
+import urllib.parse
 import requests
 import json
 import base64
@@ -61,6 +61,10 @@ from .models import DocumentsMetadataModel
 from .models import PageOfModel
 from .util import build_query
 from .util import PKCS12Certificate
+
+
+def urljoin(base, path):
+    return urllib.parse.urljoin(base, urllib.parse.urlparse(path).path)
 
 
 class RestChain :
@@ -732,7 +736,7 @@ class RestNode :
         verify_ca (:obj:`bool`): If True, checks CA.
 
     Attributes:
-        base_uri (:obj:`uri.URI`): The base URI address of the node.
+        base_uri (:obj:`str`): The base URI address of the node.
         network (:obj:`RestNetwork`): Network information client.
     """
 
@@ -741,7 +745,7 @@ class RestNode :
             port = NetworkPredefinedPorts.MainNet.value
         
         self.verify_ca = verify_ca
-        self.base_uri = uri.URI(f'https://{address}:{port}/')
+        self.base_uri = f'https://{address}:{port}/'
         #self.__certificate = self.__get_cert_from_file(cert_file, cert_pass)
         self.__certificate = PKCS12Certificate(cert_file, cert_pass)
         self.network = RestNetwork(self)
@@ -962,7 +966,7 @@ class RestNode :
         return
     
     def _download_file(self, url, dst_path='./') :
-        cur_uri = uri.URI(self.base_uri, path=url)
+        cur_uri = urljoin(self.base_uri, path=url)
         s = self._get_session()
         with s.get(cur_uri, stream=True) as r:
             d = r.headers['content-disposition']
@@ -973,7 +977,7 @@ class RestNode :
         return
 
     def _get_raw_response(self, url, method, accept) :
-        cur_uri = uri.URI(self.base_uri, path=url)
+        cur_uri = urljoin(self.base_uri, path=url)
         s = self._get_session()
         response = s.request(method=method, url=cur_uri, stream=True,
                                 headers={'Accept': accept})
@@ -982,7 +986,7 @@ class RestNode :
         return response
 
     def _prepare_request(self, url, method, accept) :
-        cur_uri = uri.URI(self.base_uri, path=url)
+        cur_uri = urljoin(self.base_uri, path=url)
         s = self._get_session()
         response = s.request(method=method, url=cur_uri, stream=True,
                                 headers={'Accept': accept})
@@ -991,7 +995,7 @@ class RestNode :
         return response
 
     def _prepare_post_request(self, url, body, accept) :
-        cur_uri = uri.URI(self.base_uri, path=url)
+        cur_uri = urljoin(self.base_uri, path=url)
         
         if issubclass(type(body) ,BaseModel) :
             json_data = body.json()
@@ -1007,7 +1011,7 @@ class RestNode :
         
 
     def _prepare_post_raw_request(self, url, body, accept, contentType) :
-        cur_uri = uri.URI(self.base_uri, path=url)
+        cur_uri = urljoin(self.base_uri, path=url)
         headers = {'Accept': accept,
                    'Content-type': contentType}
         
@@ -1017,7 +1021,7 @@ class RestNode :
         return response
 
     def _prepare_post_file_request(self, url, file_path, accept, contentType) :
-        cur_uri = uri.URI(self.base_uri, path=url)
+        cur_uri = urljoin(self.base_uri, path=url)
         headers = {'Accept': accept,
                    'Content-type': contentType}
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ colour>=0.1.5
 packaging>=19.2
 pyOpenSSL>=19.1.0
 requests>=2.22.0
-uri>=2.0.1

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setuptools.setup(
     install_requires=[
           'colour>=0.1.5',
           'packaging>=19.2',
-          'uri>=2.0.1',
           'requests>=2.22.0',
           'pyOpenSSL>= 19.1.0',
           'pyilint>=0.2.0',


### PR DESCRIPTION
The `uri` package seems to be unmaintained and is incompatible with python 3.10

This PR replaces it with the built-in `urllib.parse`